### PR TITLE
Fix typo in login page doc comment

### DIFF
--- a/tests/codeception/common/_pages/LoginPage.php
+++ b/tests/codeception/common/_pages/LoginPage.php
@@ -6,7 +6,7 @@ use yii\codeception\BasePage;
 use common\models\LoginForm;
 
 /**
- * Represents loging page
+ * Represents login page
  * @property \tests\codeception\frontend\AcceptanceTester|\tests\codeception\frontend\FunctionalTester|\tests\codeception\backend\AcceptanceTester|\tests\codeception\backend\FunctionalTester $actor
  */
 class LoginPage extends BasePage


### PR DESCRIPTION
## Summary
- fix typo in LoginPage PHPDoc comment

## Testing
- `php -l tests/codeception/common/_pages/LoginPage.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840e2a7f0288330a51bad15af341bf6